### PR TITLE
Fixed crash and added missing argc/argv

### DIFF
--- a/autoaccept.cpp
+++ b/autoaccept.cpp
@@ -14,7 +14,7 @@
 #include "leaguefiles.cpp"
 #include "curling.cpp"
 
-int main() {
+int main(int argc, char** argv) {
     (argc != 1 && static_cast<std::string>(argv[1]) == "--nopkexec") ? : system("pkexec sh -c 'sysctl -w abi.vsyscall32=0' > /dev/null");
     std::cout << "STARTED LEAGUEAUTOACCEPT" << std::endl;
 //    std::cout << std::unitbuf;

--- a/leaguefiles.cpp
+++ b/leaguefiles.cpp
@@ -10,7 +10,9 @@ struct leagueDBfind {
     sqlite3 *database;
 
     leagueDBfind() { // constructor tries to find the location of the lutris database with the XDG_DATA_HOME environmental variable. If it doesn't, it gets set to ~/.local/share/lutris/pga.db
-        XDG_DATA_HOME = std::getenv("XDG_DATA_HOME");
+        char* env = std::getenv("XDG_DATA_HOME");
+        XDG_DATA_HOME = env ? env : "";
+
         databaselocation = XDG_DATA_HOME.empty() ? "" : XDG_DATA_HOME+"/lutris/pga.db";
         if (XDG_DATA_HOME.empty()) {
             std::cout << "Environmental var: XDG_DATA_HOME doesn't exist. defaulting to ~/.local/share\n";


### PR DESCRIPTION
I just tried your script and its awesome and it actually worked, had to do some changes to make it running though. 
I compiled it with
```
$ g++ -o test autoaccept.cpp -lcurl -lsqlite3
```
and got an error message duo to missing `argc` and `argv` in the main function. Another problem I had was if `XDG_DATA_HOME` was not set the `getenv` would set the `std::string` to a nullptr which caused the program to crash. So I added an additional check.
 